### PR TITLE
🧑🏼‍🦽 Break word at end of bio div

### DIFF
--- a/frontend/src/components/css/Profile.scss
+++ b/frontend/src/components/css/Profile.scss
@@ -85,6 +85,7 @@
 
   .mentor-profile-about {
     width: 90%;
+    word-wrap: break-word;
   }
 
   .mentor-specialization-tag {


### PR DESCRIPTION
<!--
WELCOME TO OUR PULL REQUEST TEMPLATE THAT I STOLE FROM LAH! :partyparrot:
Not all sections apply, feel free to delete as appropriate.
-->
## Status:
:construction: In development


## Description :star2:
<!--
A few sentences describing the overall goals of the pull request's commits.
INCLUDE A SCREENSHOT IF THIS IS FRONTEND
-->

Adjust the CSS for the div that holds this about text to break words so an extremely long word will go to the newline. This solution does not truncate, so if we want to add that I can do it as well. 

![image](https://user-images.githubusercontent.com/23776635/134583918-3f4f34a5-967b-427a-b7e3-19dd0a97942d.png)

Fixes #345
 
## TODOs :star:
<!--
- [ ] Tests
- [ ] Documentation
-->