### PR TITLE
🚃 Fixed card css and header profile icon margins

### DIFF
--- a/frontend/src/components/MenteeCard.js
+++ b/frontend/src/components/MenteeCard.js
@@ -51,13 +51,12 @@ function MenteeCard(props) {
         <div className="gallery-card-header">
           <Avatar size={90} icon={getImage(props.image && props.image.url)} />
           <div className="gallery-header-text gallery-info-section">
-            <Title style={styles.title} className="gallery-title-text">
+            <div className="gallery-header-name">
               {props.name}
-              {","} {props.age}
-            </Title>
-            <Title style={styles.subTitle} type="secondary" level={5}>
+            </div>
+            <div className="gallery-header-description">
               {props.gender} {"|"} {props.organization}
-            </Title>
+            </div>
           </div>
         </div>
         {props.location && (
@@ -74,8 +73,8 @@ function MenteeCard(props) {
           Languages:
         </h3>
         <Text className="gallery-list-items">{props.languages.join(", ")}</Text>
-        <hr className="gallery-solid-border" />
-        <div className="bookmark-button"></div>
+      </div>
+      <div className="gallery-card-footer">
         <NavLink to={`/gallery/${ACCOUNT_TYPE.MENTEE}/${props.id}`}>
           <div className="gallery-button">
             <MenteeButton content="View Profile" />

--- a/frontend/src/components/MenteeCard.js
+++ b/frontend/src/components/MenteeCard.js
@@ -51,9 +51,7 @@ function MenteeCard(props) {
         <div className="gallery-card-header">
           <Avatar size={90} icon={getImage(props.image && props.image.url)} />
           <div className="gallery-header-text gallery-info-section">
-            <div className="gallery-header-name">
-              {props.name}
-            </div>
+            <div className="gallery-header-name">{props.name}</div>
             <div className="gallery-header-description">
               {props.gender} {"|"} {props.organization}
             </div>

--- a/frontend/src/components/MentorCard.js
+++ b/frontend/src/components/MentorCard.js
@@ -129,16 +129,13 @@ function MentorCard(props) {
             </a>
           </h4>
         )}
-        <div className="bookmark-button"></div>
-        <div className="gallery-card-footer">
-          <hr className="gallery-solid-border" />
-
-          <NavLink to={`/gallery/${ACCOUNT_TYPE.MENTOR}/${props.id}`}>
-            <div className="gallery-button">
-              <MenteeButton content="View Profile" />
-            </div>
-          </NavLink>
-        </div>
+      </div>
+      <div className="gallery-card-footer">
+        <NavLink to={`/gallery/${ACCOUNT_TYPE.MENTEE}/${props.id}`}>
+          <div className="gallery-button">
+            <MenteeButton content="View Profile" />
+          </div>
+        </NavLink>
       </div>
     </div>
   );

--- a/frontend/src/components/css/Gallery.scss
+++ b/frontend/src/components/css/Gallery.scss
@@ -5,7 +5,6 @@
   flex-direction: row;
   padding: 1vh;
   background-color: white;
-  
 }
 
 .gallery-filter-container {
@@ -26,6 +25,17 @@
   color: $theme-orange-dark;
   font-weight: bold;
   font-size: 16px;
+}
+
+.gallery-header-name {
+  font-size: 35px;
+  font-weight: bold;
+}
+
+.gallery-header-description {
+  font-size: 18px;
+  font-weight: 600;
+  color: rgba(0, 0, 0, 0.45);
 }
 
 .gallery-mentor-container {
@@ -52,6 +62,8 @@
   border-radius: 8px;
   position: relative;
   height: 33em;
+  padding: 20px;
+  padding-top: 0px;
 }
 
 .gallery-mentor-card:hover {
@@ -71,11 +83,6 @@
   border-radius: 50%;
   margin-right: 10px;
   display: inline-block;
-}
-
-.gallery-solid-border {
-  border-top: 3px solid $theme-orange;
-  margin-top: 20px;
 }
 
 .gallery-card-header {
@@ -133,22 +140,17 @@
   color: $theme-orange-dark;
   margin: 0;
   text-align: left;
-
 }
 
 .gallery-list-items {
   display: block;
   text-align: left;
   padding-left: 27px;
-  padding-bottom: 20px;
-}
-
-.gallery-card-body {
-  padding: 20px;
-  padding-top: 0px;
+  padding-bottom: 12px;
 }
 
 .gallery-card-footer {
+  border-top: 3px solid $theme-orange;
   position: absolute;
   bottom: 0px;
   width: 90%;

--- a/frontend/src/components/css/Navigation.scss
+++ b/frontend/src/components/css/Navigation.scss
@@ -123,6 +123,7 @@
   float: right;
   margin-top: 15px;
   margin-left: 1%;
+  margin-right: 12px;
   font-size: 15px;
   line-height: 15px;
   white-space: nowrap;


### PR DESCRIPTION
<!--
WELCOME TO OUR PULL REQUEST TEMPLATE THAT I STOLE FROM LAH! :partyparrot:
Not all sections apply, feel free to delete as appropriate.
-->
## Status: :rocket: Ready
<!--
:rocket: Ready
:construction: In development
:no_entry_sign: Do not merge
-->

## Description :star2:
This PR fixes a few quick css bugs, mainly:
- Profile icon on top right now has proper margins
- Cards now properly have 'view profile' buttons stuck to bottom of card
- Spacing between information is slimmed
- Text overflow in header is now properly handled to be ellipses

<!--
A few sentences describing the overall goals of the pull request's commits.
INCLUDE A SCREENSHOT IF THIS IS FRONTEND
-->
Before:

![Screen Shot 2021-12-05 at 11 25 03 AM](https://user-images.githubusercontent.com/29765024/144756744-76340404-28b9-4e20-90d7-73adea6eb8fa.png)

![Screen Shot 2021-12-05 at 11 24 14 AM](https://user-images.githubusercontent.com/29765024/144756748-a909e7de-ef14-426c-8fe5-1eae29c1261f.png)

After:

![Screen Shot 2021-12-05 at 11 18 01 AM](https://user-images.githubusercontent.com/29765024/144756705-ea48c663-6139-4e84-a439-9c0d284ccb47.png)

![Screen Shot 2021-12-05 at 11 21 38 AM](https://user-images.githubusercontent.com/29765024/144756703-6f2db306-a075-4524-8627-d77c8a39f0c7.png)

## TODOs :star:
<!--
- [ ] Tests
- [ ] Documentation
-->
