### PR TITLE
☄️ Multiple CSS and code cleanup Messages/Appointments

### DIFF
--- a/backend/api/views/appointment.py
+++ b/backend/api/views/appointment.py
@@ -297,7 +297,7 @@ def delete_request(appointment_id):
         if not res_email:
             logger.info("Failed to send email")
 
-    request.status = APPT_STATUS["REJECTED"]
+    request.status = APPT_STATUS["DENIED"]
     request.save()
     return create_response(status=200, message=f"Success")
 

--- a/frontend/src/components/AppointmentInfo.js
+++ b/frontend/src/components/AppointmentInfo.js
@@ -56,57 +56,17 @@ function AppointmentInfo(props) {
     return subtextInfo.join(" • ");
   };
 
-  const displayButtons = () => {
-    if (props.current_tab.key === Tabs.pending.key) {
-      return (
-        <div style={{ textAlign: "center" }}>
-          <MenteeButton
-            content={"Accept"}
-            border={"1px solid green"}
-            onClick={() =>
-              props.handleAppointmentClick(props.modalAppointment.id, true)
-            }
-          />
-          <MenteeButton
-            content={"Deny"}
-            border={"1px solid red"}
-            onClick={() =>
-              props.handleAppointmentClick(props.modalAppointment.id, false)
-            }
-          />
-        </div>
-      );
-    } else {
-      return (
-        <div style={{ textAlign: "center" }}>
-          <MenteeButton
-            content={t("common.deny")}
-            border={"1px solid red"}
-            onClick={() =>
-              props.handleAppointmentClick(props.modalAppointment.id, false)
-            }
-          />
-        </div>
-      );
-    }
-  };
-
-  const pendingOrUpcoming = () => {
-    if (props.current_tab === Tabs.pending) {
-      return (
-        <div className="ar-status">
-          pending<span className="pending-dot"></span>
-        </div>
-      );
-    } else {
-      return (
-        <div className="ar-status">
-          {t("appointmentStatus.accepted")}
-          <span className="upcoming-dot"></span>
-        </div>
-      );
-    }
-  };
+  const displayButtons = () => (
+    <div style={{ textAlign: "center" }}>
+      <MenteeButton
+        content={t("common.deny")}
+        border={"1px solid red"}
+        onClick={() =>
+          props.handleAppointmentClick(props.modalAppointment.id, false)
+        }
+      />
+    </div>
+  );
 
   const allowsContact = (allow_calls, allow_texts, phone_number) => {
     if (!phone_number) {
@@ -150,13 +110,11 @@ function AppointmentInfo(props) {
   return (
     <Modal
       open={props.modalVisible}
-      title={t("sidebars.appointments")}
       width="449.91px"
       onCancel={() => props.setModalVisible(false)}
       footer={displayButtons()}
     >
       <div className="ar-modal-container">
-        {pendingOrUpcoming()}
         <div>
           <div>
             {allowsContact(
@@ -167,6 +125,10 @@ function AppointmentInfo(props) {
           </div>
           <div className="ar-modal-title">
             {mentee.name}, {mentee.age}
+          </div>
+          <div className="ar-status">
+            <span className="upcoming-dot"></span>
+            {t("appointmentStatus.accepted")}
           </div>
         </div>
         <div className="personal-info">

--- a/frontend/src/components/MessagesChatArea.js
+++ b/frontend/src/components/MessagesChatArea.js
@@ -8,6 +8,7 @@ import {
   Modal,
   TimePicker,
   theme,
+  Drawer,
 } from "antd";
 import { withRouter } from "react-router-dom";
 import { ACCOUNT_TYPE } from "utils/consts";
@@ -569,24 +570,45 @@ function MessagesChatArea(props) {
         )}
       </div>
 
-      <Modal
-        className="calendar-modal"
-        title={t("messages.availabilityTitle")}
-        open={isOpenCalendarModal}
-        onCancel={() => setIsOpenCalendarModal(false)}
-        footer={[
-          <Button
-            type="primary"
-            onClick={() => {
-              setIsOpenCalendarModal(false);
-            }}
-          >
-            {t("common.cancel")}
-          </Button>,
-        ]}
-      >
-        <AvailabilityCalendar appointmentdata={appointments} />
-      </Modal>
+      {isMobile ? (
+        <Drawer
+          width={"100%"}
+          title={t("messages.availabilityTitle")}
+          open={isOpenCalendarModal}
+          onClose={() => setIsOpenCalendarModal(false)}
+          footer={[
+            <Button
+              type="primary"
+              onClick={() => {
+                setIsOpenCalendarModal(false);
+              }}
+            >
+              {t("common.cancel")}
+            </Button>,
+          ]}
+        >
+          <AvailabilityCalendar appointmentdata={appointments} />
+        </Drawer>
+      ) : (
+        <Modal
+          className="calendar-modal"
+          title={t("messages.availabilityTitle")}
+          open={isOpenCalendarModal}
+          onCancel={() => setIsOpenCalendarModal(false)}
+          footer={[
+            <Button
+              type="primary"
+              onClick={() => {
+                setIsOpenCalendarModal(false);
+              }}
+            >
+              {t("common.cancel")}
+            </Button>,
+          ]}
+        >
+          <AvailabilityCalendar appointmentdata={appointments} />
+        </Modal>
+      )}
     </div>
   );
 }

--- a/frontend/src/components/MessagesChatArea.js
+++ b/frontend/src/components/MessagesChatArea.js
@@ -571,6 +571,7 @@ function MessagesChatArea(props) {
       </div>
 
       {isMobile ? (
+        // TODO: Consolidate the modal and drawer into one component
         <Drawer
           width={"100%"}
           title={t("messages.availabilityTitle")}

--- a/frontend/src/components/MessagesSidebar.js
+++ b/frontend/src/components/MessagesSidebar.js
@@ -76,15 +76,7 @@ function MessagesSidebar(props) {
         <h1>{t("messages.sidebarTitle")}</h1>
       </div>
       <Divider className="header-divider" orientation="left"></Divider>
-      <div className="messages-search-input">
-        {/* <Input
-          placeholder="Search for a mentor..."
-          prefix={<SearchOutlined />}
-          style={styles.searchInput}
-          onChange={(e) => setSearchQuery(e.target.value)}
-        /> */}
-      </div>
-      <div className="messages-sidebar">
+      <div className="messages-sidebar" style={{ paddingTop: "1em" }}>
         {side_data &&
           side_data.length > 0 &&
           side_data.map((chat) => {

--- a/frontend/src/components/css/Appointments.scss
+++ b/frontend/src/components/css/Appointments.scss
@@ -48,23 +48,6 @@
   height: 50px;
 }
 
-.ar-status {
-  position: relative;
-  width: 80px;
-  height: 37.8px;
-  left: 335.14px;
-  top: 20px;
-
-  font-family: Helvetica;
-  font-style: italic;
-  font-weight: bold;
-  font-size: 12px;
-  line-height: 14px;
-  text-align: right;
-
-  color: #828282;
-}
-
 .ar-modal-title {
   position: relative;
   width: 201px;
@@ -83,6 +66,7 @@
 .ar-phone,
 .ar-contact,
 .ar-email,
+.ar-status,
 .ar-email-only {
   position: relative;
   width: 189px;

--- a/frontend/src/components/css/Messages.scss
+++ b/frontend/src/components/css/Messages.scss
@@ -50,7 +50,7 @@
 
 .messages-sidebar-header {
   background-color: white;
-  overflow-y: auto;
+  overflow-y: hidden;
   padding-left: 10%;
   font-size: 3ch;
   height: 89px;

--- a/frontend/src/components/pages/Appointments.js
+++ b/frontend/src/components/pages/Appointments.js
@@ -11,6 +11,7 @@ import {
   notification,
   Spin,
   theme,
+  Tabs,
 } from "antd";
 import {
   ClockCircleOutlined,
@@ -38,10 +39,9 @@ import ModalInput from "components/ModalInput";
 import { useTranslation } from "react-i18next";
 import { getTranslatedOptions } from "utils/translations";
 import { useMediaQuery } from "react-responsive";
+import i18n from "utils/i18n";
 
-//TODO: Fix this tabs rendering translation
-
-const Tabs = Object.freeze({
+const TabKeys = Object.freeze({
   upcoming: "upcoming",
   past: "past",
   availability: "availability",
@@ -54,8 +54,7 @@ function Appointments() {
   } = theme.useToken();
   const { t } = useTranslation();
   const [isLoading, setIsLoading] = useState(true);
-  const [currentTab, setCurrentTab] = useState(Tabs.upcoming);
-  const tabTitles = {
+  const tabLabels = {
     upcoming: t("mentorAppointmentPage.upcoming"),
     past: t("mentorAppointmentPage.past"),
     availability: t("mentorAppointmentPage.availability"),
@@ -79,6 +78,7 @@ function Appointments() {
   const [selectedDate, setSelectedDate] = useState();
   const [selectedStarttime, setSelectedStarttime] = useState();
   const [selectedEndtime, setSelectedEndtime] = useState();
+  const [currentTab, setCurrentTab] = useState("upcoming");
   const [form] = Form.useForm();
 
   const dispatch = useDispatch();
@@ -159,7 +159,7 @@ function Appointments() {
     }
 
     onAuthStateChanged(getAppointments);
-  }, [appointmentClick, profileId, onAuthStateChanged]);
+  }, [appointmentClick, profileId, onAuthStateChanged, i18n.language]);
 
   useEffect(() => {
     getMentees();
@@ -243,49 +243,22 @@ function Appointments() {
     setAppointmentClick(!appointmentClick);
     setModalVisible(false);
   }
-  // TODO: Swap this to emotion styled components
-  const getButtonStyle = (tab) => {
-    const active = colorPrimary;
-    const inactive = "white";
-    return {
-      borderRadius: 13,
-      marginRight: 15,
-      backgroundColor: currentTab === tab ? active : inactive,
-    };
-  };
-  const getButtonTextStyle = (tab) => {
-    const active = "white";
-    const inactive = colorPrimary;
-    return {
-      fontWeight: 700,
-      color: currentTab === tab ? active : inactive,
-    };
-  };
-  const Tab = (props) => (
-    <Button
-      shape="round"
-      size={isMobile ? "small" : "middle"}
-      style={getButtonStyle(props.tab)}
-      onClick={() => setCurrentTab(props.tab)}
-    >
-      <div style={getButtonTextStyle(props.tab)}>{props.text}</div>
-    </Button>
-  );
+
   const getAppointmentButton = (tab, info) => {
-    if (tab === Tabs.upcoming) {
+    if (tab === TabKeys.upcoming) {
       return (
         <Button
           className="appointment-more-details"
           icon={
             <InfoCircleFilled
-              style={{ ...styles.appointment_buttons, color: colorPrimary }}
+              style={{ ...styles.appointmentButtons, color: colorPrimary }}
             />
           }
           type="text"
           onClick={() => ViewAppointmentDetails(info)}
         ></Button>
       );
-    } else if (tab === Tabs.pending) {
+    } else if (tab === TabKeys.pending) {
       return (
         <MenteeButton
           content={<b>Review</b>}
@@ -352,7 +325,7 @@ function Appointments() {
     }
     return (
       <div>
-        <b className="appointment-tabs-title">{tabTitles[currentTab.key]}</b>
+        <b className="appointment-tabs-title">{tabLabels[currentTab.key]}</b>
         <div className="appointments-background">
           {data.map((appointmentsObject, index) => (
             <div key={index} className="appointments-date-block">
@@ -374,18 +347,25 @@ function Appointments() {
       </div>
     );
   };
-  function renderTab(tab) {
-    switch (tab) {
-      case Tabs.upcoming: // Fall through
-      case Tabs.pending: // Fall through
-      case Tabs.past:
-        return <Appointments data={appointments[currentTab]} />;
-      case Tabs.availability:
-        return <AvailabilityTab data={appointments[Tabs.upcoming]} />;
-      default:
-        return <div />;
-    }
-  }
+
+  const tabItems = [
+    {
+      key: TabKeys.upcoming,
+      label: tabLabels.upcoming,
+      children: <Appointments data={appointments[TabKeys.upcoming]} />,
+    },
+    {
+      key: TabKeys.past,
+      label: tabLabels.past,
+      children: <Appointments data={appointments[TabKeys.past]} />,
+    },
+    {
+      key: TabKeys.availability,
+      label: tabLabels.availability,
+      children: <AvailabilityTab data={appointments[TabKeys.upcoming]} />,
+    },
+  ];
+
   return (
     <div>
       <AppointmentInfo
@@ -416,7 +396,6 @@ function Appointments() {
             style={{
               marginLeft: "1%",
               marginTop: "12px",
-              marginBottom: "15px",
             }}
           >
             <MenteeButton
@@ -427,14 +406,15 @@ function Appointments() {
                 setManualModalvisible(true);
               }}
             />
-          </div>
-          <div className="appointments-tabs">
-            {Object.keys(tabTitles).map((tab, index) => (
-              <Tab tab={tab} text={tabTitles[tab]} key={index} />
-            ))}
+            <Spin spinning={isLoading}>
+              <Tabs
+                items={tabItems}
+                defaultActiveKey="upcoming"
+                onChange={(tab) => setCurrentTab(tab)}
+              />
+            </Spin>
           </div>
         </div>
-        <Spin spinning={isLoading}>{renderTab(currentTab)}</Spin>
       </div>
       <Modal
         className="manual-add-modal"
@@ -476,7 +456,6 @@ function Appointments() {
               type="dropdown-single-object"
               options={menteeArr}
               placeholder={t("mentorAppointmentPage.selectMentee")}
-              // clicked={inputClicked[0]}
               index={0}
               handleClick={() => {}}
               onChange={(value) => {
@@ -611,7 +590,7 @@ const styles = {
   calendar: {
     borderLeft: "3px solid #E5E5E5",
   },
-  appointment_buttons: {
+  appointmentButtons: {
     fontSize: "24px",
   },
 };

--- a/frontend/src/components/pages/Appointments.js
+++ b/frontend/src/components/pages/Appointments.js
@@ -3,10 +3,7 @@ import moment from "moment";
 import {
   Form,
   Button,
-  Col,
-  Row,
   Result,
-  Badge,
   Checkbox,
   Modal,
   TimePicker,
@@ -40,7 +37,6 @@ import { updateAndFetchUser } from "features/userSlice";
 import ModalInput from "components/ModalInput";
 import { useTranslation } from "react-i18next";
 import { getTranslatedOptions } from "utils/translations";
-import { css } from "@emotion/css";
 
 //TODO: Fix this tabs rendering translation
 
@@ -69,13 +65,11 @@ function Appointments() {
   const options = useSelector((state) => state.options);
   const [modalAppointment, setModalAppointment] = useState({});
   const { isAdmin, onAuthStateChanged, role, profileId } = useAuth();
-  const [pendingAppointmentCount, setPendingAppointmentCount] = useState(0);
   const [takeAppoinment, setTakeappoinment] = useState(
     user?.taking_appointments
   );
 
   const [manualModalvisible, setManualModalvisible] = useState(false);
-  const [mentees, setMentees] = useState([]);
   const [menteeArr, setMenteeArr] = useState([]);
   const [topic, setTopic] = useState();
   const [message, setMessage] = useState();
@@ -109,7 +103,6 @@ function Appointments() {
             }
             return false;
           });
-          setMentees(temp);
         }
       } else {
         var restricted_partners = await fetchPartners(true);
@@ -131,10 +124,8 @@ function Appointments() {
             }
             return false;
           });
-          setMentees(temp);
         } else {
           temp = mentee_data;
-          setMentees(mentee_data);
         }
       }
     }
@@ -160,9 +151,6 @@ function Appointments() {
       if (formattedAppointments) {
         setAppointments(formattedAppointments);
         if (formattedAppointments["pending"][0]) {
-          setPendingAppointmentCount(
-            formattedAppointments["pending"][0]["appointments"].length
-          );
         }
       }
       setIsLoading(false);
@@ -273,8 +261,8 @@ function Appointments() {
   };
   const Tab = (props) => (
     <Button
-      type="default"
       shape="round"
+      size="small"
       style={getButtonStyle(props.tab)}
       onClick={() => setCurrentTab(props.tab)}
     >

--- a/frontend/src/components/pages/Appointments.js
+++ b/frontend/src/components/pages/Appointments.js
@@ -40,6 +40,7 @@ import { updateAndFetchUser } from "features/userSlice";
 import ModalInput from "components/ModalInput";
 import { useTranslation } from "react-i18next";
 import { getTranslatedOptions } from "utils/translations";
+import { css } from "@emotion/css";
 
 //TODO: Fix this tabs rendering translation
 
@@ -51,12 +52,7 @@ const Tabs = Object.freeze({
 
 function Appointments() {
   const {
-    token: {
-      colorPrimaryBg,
-      colorPrimaryBorder,
-      colorBorderSecondary,
-      colorPrimary,
-    },
+    token: { colorPrimary },
   } = theme.useToken();
   const { t } = useTranslation();
   const [isLoading, setIsLoading] = useState(true);
@@ -275,33 +271,16 @@ function Appointments() {
       color: currentTab === tab ? active : inactive,
     };
   };
-  const Tab = (props) => {
-    if (props.text === "All Pending") {
-      return (
-        <Button
-          type="primary"
-          shape="round"
-          style={getButtonStyle(props.tab)}
-          onClick={() => setCurrentTab(props.tab)}
-        >
-          <Badge count={pendingAppointmentCount ?? 0} size="small">
-            <div style={getButtonTextStyle(props.tab)}>{props.text}</div>
-          </Badge>
-        </Button>
-      );
-    } else {
-      return (
-        <Button
-          type="default"
-          shape="round"
-          style={getButtonStyle(props.tab)}
-          onClick={() => setCurrentTab(props.tab)}
-        >
-          <div style={getButtonTextStyle(props.tab)}>{props.text}</div>
-        </Button>
-      );
-    }
-  };
+  const Tab = (props) => (
+    <Button
+      type="default"
+      shape="round"
+      style={getButtonStyle(props.tab)}
+      onClick={() => setCurrentTab(props.tab)}
+    >
+      <div style={getButtonTextStyle(props.tab)}>{props.text}</div>
+    </Button>
+  );
   const getAppointmentButton = (tab, info) => {
     if (tab === Tabs.upcoming) {
       return (
@@ -375,7 +354,7 @@ function Appointments() {
       return (
         <div className="empty-appointments-list appointments-background">
           <Result
-            icon={<SmileOutlined />}
+            icon={<SmileOutlined style={{ color: colorPrimary }} />}
             title={t("mentorAppointmentPage.noAppointments")}
           />
         </div>

--- a/frontend/src/components/pages/Appointments.js
+++ b/frontend/src/components/pages/Appointments.js
@@ -37,6 +37,7 @@ import { updateAndFetchUser } from "features/userSlice";
 import ModalInput from "components/ModalInput";
 import { useTranslation } from "react-i18next";
 import { getTranslatedOptions } from "utils/translations";
+import { useMediaQuery } from "react-responsive";
 
 //TODO: Fix this tabs rendering translation
 
@@ -47,6 +48,7 @@ const Tabs = Object.freeze({
 });
 
 function Appointments() {
+  const isMobile = useMediaQuery({ query: "(max-width: 768px)" });
   const {
     token: { colorPrimary },
   } = theme.useToken();
@@ -262,7 +264,7 @@ function Appointments() {
   const Tab = (props) => (
     <Button
       shape="round"
-      size="small"
+      size={isMobile ? "small" : "middle"}
       style={getButtonStyle(props.tab)}
       onClick={() => setCurrentTab(props.tab)}
     >

--- a/frontend/src/utils/dateFormatting.js
+++ b/frontend/src/utils/dateFormatting.js
@@ -21,7 +21,7 @@ export const formatAppointments = (data, type) => {
   let appointments = data.requests;
   if (type === ACCOUNT_TYPE.MENTOR) {
     appointments = data.requests.filter(
-      (elem) => !elem.status || elem.status !== APPOINTMENT_STATUS.REJECTED
+      (elem) => elem?.status !== APPOINTMENT_STATUS.DENIED
     );
   }
 


### PR DESCRIPTION
<!--
WELCOME TO OUR PULL REQUEST TEMPLATE THAT I STOLE FROM LAH! :partyparrot:
Not all sections apply, feel free to delete as appropriate.
-->
## Status: :rocket: Ready
<!--
:rocket: Ready
:construction: In development
:no_entry_sign: Do not merge
-->

## Description :star2:
<!--
A few sentences describing the overall goals of the pull request's commits.
INCLUDE A SCREENSHOT IF THIS IS FRONTEND
-->
- Updated no appointments smile color
- Changed to tabs instead of buttons
- Update color indicator of appointment status not showing on modal
- Add mobile responsiveness to calendar for messages availability (Renders a drawer instead of modal)
- Consolidate differences in appointment status constants such as "Rejected" and "denied"
- removed unused states for mentee and appointments
