### PR TITLE
🎞️ Make Reply Input in Group Chat Responsive on Mobile

### DIFF
--- a/frontend/src/components/GroupMessageChatArea.js
+++ b/frontend/src/components/GroupMessageChatArea.js
@@ -468,7 +468,7 @@ function GroupMessageChatArea(props) {
   };
   const screens = useBreakpoint();
 
-  const MAX_XS_INDENT_DEPTH = 3;
+  const MAX_XS_INDENT_DEPTH = 4;
   const computeIndent = (d) => {
     const isSmall = !screens.md;          // true when width < 768px
     const base = isSmall ? 16 : 40;       // per-level indent
@@ -789,7 +789,7 @@ function GroupMessageChatArea(props) {
           {block.children &&
             block.children.length > 0 &&
             expandedMessages[block._id.$oid] && (
-              <div style={{ marginLeft: "20px" }}>
+              <div style={{ marginLeft: 0 }}>
                 {renderMessages(block.children, depth + 1)}
               </div>
             )}

--- a/frontend/src/components/GroupMessageChatArea.js
+++ b/frontend/src/components/GroupMessageChatArea.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useState, useRef } from "react";
-import { Avatar, Input, Button, Spin, theme, Dropdown, Popconfirm } from "antd";
+import { Avatar, Input, Button, Spin, theme, Dropdown, Popconfirm ,Grid} from "antd";
 import { withRouter, NavLink } from "react-router-dom";
 import moment from "moment-timezone";
 import { SendOutlined, EditOutlined, DeleteOutlined } from "@ant-design/icons";
@@ -14,6 +14,9 @@ import {
 import { useTranslation } from "react-i18next";
 import { css } from "@emotion/css";
 import { ACCOUNT_TYPE } from "utils/consts";
+
+
+const { useBreakpoint } = Grid;
 
 function GroupMessageChatArea(props) {
   const {
@@ -463,19 +466,30 @@ function GroupMessageChatArea(props) {
 
     return formattedText;
   };
+  const screens = useBreakpoint();
+
+  const MAX_XS_INDENT_DEPTH = 3;
+  const computeIndent = (d) => {
+    const isSmall = !screens.md;          // true when width < 768px
+    const base = isSmall ? 16 : 40;       // per-level indent
+    const cap  = isSmall ? 64 : 240;      // absolute pixel cap (optional)
+    const effectiveDepth = isSmall ? Math.min(d, MAX_XS_INDENT_DEPTH) : d;
+
+    return Math.min(effectiveDepth * base, cap);
+  };
 
   const renderMessages = (data, depth = 0) => {
     return data.map((block) => {
       let sender_user = particiants.find(
         (x) => x._id.$oid === block.sender_id.$oid
       );
-
+      const indent = computeIndent(depth);
       const isParent = !block.parent_message_id;
 
       return (
         <div className={isParent ? styles.parentMessageContainer : ""}>
           <div
-            style={{ marginLeft: 50 * depth + "px" }}
+              style={{ marginLeft: indent }}
             className="chatRight__items you-received"
           >
             <div

--- a/frontend/src/components/GroupMessageChatArea.js
+++ b/frontend/src/components/GroupMessageChatArea.js
@@ -1,5 +1,14 @@
 import React, { useEffect, useState, useRef } from "react";
-import { Avatar, Input, Button, Spin, theme, Dropdown, Popconfirm ,Grid} from "antd";
+import {
+  Avatar,
+  Input,
+  Button,
+  Spin,
+  theme,
+  Dropdown,
+  Popconfirm,
+  Grid,
+} from "antd";
 import { withRouter, NavLink } from "react-router-dom";
 import moment from "moment-timezone";
 import { SendOutlined, EditOutlined, DeleteOutlined } from "@ant-design/icons";
@@ -14,7 +23,6 @@ import {
 import { useTranslation } from "react-i18next";
 import { css } from "@emotion/css";
 import { ACCOUNT_TYPE } from "utils/consts";
-
 
 const { useBreakpoint } = Grid;
 
@@ -470,9 +478,9 @@ function GroupMessageChatArea(props) {
 
   const MAX_XS_INDENT_DEPTH = 4;
   const computeIndent = (d) => {
-    const isSmall = !screens.md;          // true when width < 768px
-    const base = isSmall ? 16 : 40;       // per-level indent
-    const cap  = isSmall ? 64 : 240;      // absolute pixel cap (optional)
+    const isSmall = !screens.md; // true when width < 768px
+    const base = isSmall ? 16 : 40; // per-level indent
+    const cap = isSmall ? 64 : 240; // absolute pixel cap (optional)
     const effectiveDepth = isSmall ? Math.min(d, MAX_XS_INDENT_DEPTH) : d;
 
     return Math.min(effectiveDepth * base, cap);
@@ -489,7 +497,7 @@ function GroupMessageChatArea(props) {
       return (
         <div className={isParent ? styles.parentMessageContainer : ""}>
           <div
-              style={{ marginLeft: indent }}
+            style={{ marginLeft: indent }}
             className="chatRight__items you-received"
           >
             <div

--- a/frontend/src/components/css/Messages.scss
+++ b/frontend/src/components/css/Messages.scss
@@ -580,3 +580,83 @@ $text-secondary: rgba(0, 0, 0, 0.45);
     }
   }
 }
+
+
+/* --- Fix reply input responsiveness --- */
+.reply-message-container {
+  /* let it actually shrink */
+  min-width: 0;            /* override 500px */
+  width: 100%;
+  padding-left: 0;         /* 50px eats space on phones */
+  gap: 8px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  /* allow wrapping on ultra small screens */
+  flex-wrap: nowrap;
+}
+
+.reply-message-container .reply-message-textarea,
+.reply-message-container .reply-message-textarea textarea {
+  /* critical for flex items to shrink instead of overflow */
+  flex: 1 1 auto;
+  min-width: 0;
+  width: 100% !important;
+  box-sizing: border-box;
+}
+
+.reply-message-container .reply-message-send-button {
+  flex: 0 0 auto;
+}
+
+/* Mentions list should not push layout */
+.user-list-dropdown {
+  max-width: 100%;
+  width: 100%;
+}
+
+/* Prevent the footer from causing horizontal scrollbars on mobile */
+@media (max-width: 761px) {
+  .conversation-footer {
+    width: 100%;            /* override 100vw */
+    padding: 12px;
+  }
+
+  .conversation-footer .message-input-container {
+    max-width: 100%;        /* override 80% cap */
+    margin-left: 0;
+  }
+
+  /* Let main composer be flexible too */
+  .message-with-icons {
+    flex-wrap: nowrap;
+  }
+  .message-with-icons .message-input,
+  .message-with-icons .ant-input,
+  .message-with-icons textarea {
+    min-width: 0;           /* allow shrink in flex */
+  }
+
+  /* If your phones are very narrow, allow wrap for the reply row */
+  @media (max-width: 400px) {
+    .reply-message-container {
+      flex-wrap: wrap;
+    }
+    .reply-message-container .reply-message-send-button {
+      margin-left: 0;
+      margin-top: 8px;
+    }
+  }
+}
+
+/* General text safety */
+.message-text {
+  overflow-wrap: anywhere;   /* prevent long URLs from breaking layout */
+  word-break: break-word;
+}
+
+
+.reply-message-container .emoji-container {
+  right: 8px;  /* avoid off-screen */
+}
+

--- a/frontend/src/components/css/Messages.scss
+++ b/frontend/src/components/css/Messages.scss
@@ -581,13 +581,12 @@ $text-secondary: rgba(0, 0, 0, 0.45);
   }
 }
 
-
 /* --- Fix reply input responsiveness --- */
 .reply-message-container {
   /* let it actually shrink */
-  min-width: 0;            /* override 500px */
+  min-width: 0; /* override 500px */
   width: 100%;
-  padding-left: 0;         /* 50px eats space on phones */
+  padding-left: 0; /* 50px eats space on phones */
   gap: 8px;
   display: flex;
   align-items: center;
@@ -618,12 +617,12 @@ $text-secondary: rgba(0, 0, 0, 0.45);
 /* Prevent the footer from causing horizontal scrollbars on mobile */
 @media (max-width: 761px) {
   .conversation-footer {
-    width: 100%;            /* override 100vw */
+    width: 100%; /* override 100vw */
     padding: 12px;
   }
 
   .conversation-footer .message-input-container {
-    max-width: 100%;        /* override 80% cap */
+    max-width: 100%; /* override 80% cap */
     margin-left: 0;
   }
 
@@ -634,7 +633,7 @@ $text-secondary: rgba(0, 0, 0, 0.45);
   .message-with-icons .message-input,
   .message-with-icons .ant-input,
   .message-with-icons textarea {
-    min-width: 0;           /* allow shrink in flex */
+    min-width: 0; /* allow shrink in flex */
   }
 
   /* If your phones are very narrow, allow wrap for the reply row */
@@ -651,12 +650,10 @@ $text-secondary: rgba(0, 0, 0, 0.45);
 
 /* General text safety */
 .message-text {
-  overflow-wrap: anywhere;   /* prevent long URLs from breaking layout */
+  overflow-wrap: anywhere; /* prevent long URLs from breaking layout */
   word-break: break-word;
 }
 
-
 .reply-message-container .emoji-container {
-  right: 8px;  /* avoid off-screen */
+  right: 8px; /* avoid off-screen */
 }
-


### PR DESCRIPTION
<!--
WELCOME TO OUR PULL REQUEST TEMPLATE THAT I STOLE FROM LAH! :partyparrot:
Not all sections apply, feel free to delete as appropriate.
-->
## Status:

:rocket: Ready




## Description :star2:
<!--
A few sentences describing the overall goals of the pull request's commits.
INCLUDE A SCREENSHOT IF THIS IS FRONTEND
-->

Fixed reply input on small devices as it was not appearing well as shown in screenshots below. Another fix was reply messages alignment as I stopped aligning message after a certain depth on small devices.


<h2>Before</h2>


<img width="342" height="689" alt="image" src="https://github.com/user-attachments/assets/2fdc759c-54e5-4ba7-80b9-b8e0652d42dc" />

<img width="341" height="690" alt="image" src="https://github.com/user-attachments/assets/ec846c3a-2a3c-4d5a-ab6c-d7c0b8cc3da4" />


----------------------------------

<h2> After </h2>

<img width="384" height="643" alt="image" src="https://github.com/user-attachments/assets/525074ba-897e-45a6-9a5a-e721c9ede653" />

<img width="410" height="902" alt="image" src="https://github.com/user-attachments/assets/a79c0ab6-b2fd-484d-b540-3d49dfe00c71" />

-----------------------------------

<h2> Before </h2>

<img width="480" height="602" alt="image" src="https://github.com/user-attachments/assets/8367f6e5-3e08-4c00-b32f-752ba7afdf51" />




-------------------------------

<h2> After </h2>

<img width="321" height="605" alt="image" src="https://github.com/user-attachments/assets/ac958ce6-8585-4911-99e7-fa999ec90a35" />







